### PR TITLE
Instantiate tokenStorage

### DIFF
--- a/utils/request.js
+++ b/utils/request.js
@@ -1,5 +1,5 @@
 const { apiHost } = require("../env");
-const { ACCESS_TOKEN } = require("../constants");
+const tokenStorage = require("./tokenStorage");
 
 const checkRes = res => {
   const { statusCode } = res;
@@ -30,9 +30,9 @@ const requestWithoutAuth = ({ type, url, options }) => {
 
 const requestWithAuth = ({ type, url, options = {} }) => {
   return new Promise((resolve, reject) => {
-    wx.getStorage({
-      key: ACCESS_TOKEN,
-      success: res => {
+    tokenStorage
+      .getStorage()
+      .then(res => {
         const access_token = res && res.data;
         wx[type]({
           url,
@@ -51,11 +51,10 @@ const requestWithAuth = ({ type, url, options = {} }) => {
             reject(e);
           }
         });
-      },
-      fail: e => {
+      })
+      .catch(e => {
         reject({ e, statusCode: 401 });
-      }
-    });
+      });
   });
 };
 

--- a/utils/storage.js
+++ b/utils/storage.js
@@ -1,0 +1,36 @@
+class Storage {
+  constructor(key) {
+    this.key = key;
+  }
+
+  setStorage(data) {
+    return new Promise((reject, resolve) => {
+      wx.setStorage({
+        key: this.key,
+        data,
+        success: res => {
+          reject(res);
+        },
+        fail: e => {
+          resolve(e);
+        }
+      });
+    });
+  }
+
+  getStorage() {
+    return new Promise((resolve, reject) => {
+      wx.getStorage({
+        key: this.key,
+        success: res => {
+          resolve(res);
+        },
+        fail: e => {
+          reject(e);
+        }
+      });
+    });
+  }
+}
+
+module.exports = Storage;

--- a/utils/storage.js
+++ b/utils/storage.js
@@ -4,15 +4,15 @@ class Storage {
   }
 
   setStorage(data) {
-    return new Promise((reject, resolve) => {
+    return new Promise((resolve, reject) => {
       wx.setStorage({
         key: this.key,
         data,
         success: res => {
-          reject(res);
+          resolve(res);
         },
         fail: e => {
-          resolve(e);
+          reject(e);
         }
       });
     });

--- a/utils/tokenStorage.js
+++ b/utils/tokenStorage.js
@@ -1,0 +1,6 @@
+const Storage = require("./storage");
+const { ACCESS_TOKEN } = require("../constants");
+
+const tokenStorage = new Storage(ACCESS_TOKEN);
+
+module.exports = tokenStorage;


### PR DESCRIPTION
- 添加Storage的构造方法
- 更集中管理缓存数据
- 集中封装为Promise对象
- 集中管理, key的文件引用仅一次
  - 之前问题是`ACCESS_TOKEN`多次重复出现